### PR TITLE
A clear error message when missing executable

### DIFF
--- a/src/DartSass/DartSassCompiler.cs
+++ b/src/DartSass/DartSassCompiler.cs
@@ -94,7 +94,7 @@ public class DartSassCompiler
 
             if (string.IsNullOrEmpty(pathToExecutable))
             {
-                throw new ArgumentException("Sass not found");
+                throw new ArgumentException("Dart Sass executable not found.");
             }
         }
 


### PR DESCRIPTION
A tiny PR. 

My colleague was pretty confused about the "Sass not found" 😅